### PR TITLE
cargo: bump error-chain to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 exclude = ["fixtures/*"]
 
 [dependencies]
-error-chain = "0.10"
 base64 = "0.6"
 byteorder = "1.1"
+error-chain = { version = "0.11", default-features = false }
 rust-crypto = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 //! allow you to construct rsa and dsa keys from their components, so if you
 //! generate the keys with another library (say, rust-openssl), then you can
 //! output the ssh public keys with this library.
-#![allow(unused_doc_comment)]
 
 extern crate base64;
 extern crate byteorder;


### PR DESCRIPTION
This updates error-chain to 0.11, cleaning a spurious clippy warning.
This also opts out from the default backtrace-sys feature, which can
be enabled by the consuming application instead.