### PR TITLE
reader: remove unchecked deref

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,4 @@
-//! reader
-//!
-//! this crate provides a struct for reading bytes in the OpenSSH public key format.
+//! This module provides a struct for reading bytes in the OpenSSH public key format.
 
 use errors::*;
 
@@ -36,7 +34,7 @@ impl<'a> Reader<'a> {
         // mpints might have an extra byte of zeros at the start.
         // if there is, we can just ignore it, since the number is big-endian
         let bytes = self.read_bytes()?;
-        if bytes[0] == 0 {
+        if bytes.get(0) == Some(&0) {
             Ok(&bytes[1..])
         } else {
             Ok(bytes)
@@ -54,3 +52,18 @@ impl<'a> Reader<'a> {
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reader_empty() {
+        let data = vec![];
+        let mut rd = Reader::new(data.as_ref());
+        assert!(rd.peek_int().is_err());
+        assert!(rd.read_bytes().is_err());
+        assert!(rd.read_mpint().is_err());
+        assert!(rd.read_string().is_err());
+    }
+}


### PR DESCRIPTION
This removes an unchecked deref in `read_mpint()` and adds negative
tests for all read methods.